### PR TITLE
Release v0.11.x to clojars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ pom.xml.asc
 *.iml
 .DS_Store
 /raftlog
+/.cpcache/

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject fluree/raft "0.11.2"
+(defproject com.fluree/raft "0.11.3-SNAPSHOT"
 
   :description "Raft library in Clojure used by Fluree."
 
   :author "Brian Platz"
 
-  :url "https://github.com/fluree/fluree"
+  :url "https://github.com/fluree/raft"
 
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}


### PR DESCRIPTION
This is to help with setting up a Docker environment for maintenance releases of Fluree 0.15.x.