### PR TITLE
Closing snapshot approach creates inconsistent raft state

### DIFF
--- a/src/fluree/raft.clj
+++ b/src/fluree/raft.clj
@@ -54,11 +54,6 @@
   "Closes a raft process."
   [{:keys [config] :as raft}]
   (log/info "Shutting down raft")
-  (let [{:keys [snapshot-write]} config]
-    (when (fn? snapshot-write)
-      (let [commit (-> raft raft-state-async async/<!! :commit)]
-        (snapshot-write commit
-                        #(log/info "Wrote final snapshot at for index" commit)))))
   (let [close-fn (:close-fn config)]
     (async/close! (events/event-chan raft))
     (if (fn? close-fn)


### PR DESCRIPTION
Trying to snapshot-write while closing in this manner creates inconsistency in the raft state in certain circumstances.

I believe this was done in an attempt to run Raft over S3. I don't think that is a good idea, but if we want to support that, the approach that must be taken is a blocking snapshot-write that also gets written into the Raft log. snapshotting is asyc today, for the right reasons, but we'd want to add a new event type which made a blocking option for explicit purpose of writing on close.
