### PR TITLE
Auto-repair corrupt log files + tests

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,11 +3,16 @@
         org.clojure/tools.logging {:mvn/version "1.1.0"}
         com.taoensso/nippy        {:mvn/version "3.1.1"}}
  :aliases
-       {:test
+       {:dev
+        {:extra-paths ["test"]
+         :extra-deps {com.magnars/test-with-files {:mvn/version "2021-02-17"}}}
+
+        :test
         {:extra-paths ["test"]
          :extra-deps  {com.cognitect/test-runner
                        {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                        :sha     "f597341b6ca7bb4cf027e0a34a6710ca9cb969da"}}
+                        :sha     "f597341b6ca7bb4cf027e0a34a6710ca9cb969da"}
+                       com.magnars/test-with-files {:mvn/version "2021-02-17"}}
          :main-opts   ["-m" "cognitect.test-runner"]}
 
         :jar

--- a/src/fluree/raft/log.clj
+++ b/src/fluree/raft/log.clj
@@ -2,7 +2,9 @@
   (:require [clojure.java.io :as io]
             [taoensso.nippy :as nippy]
             [clojure.tools.logging :as log])
-  (:import (java.io FileNotFoundException DataInputStream RandomAccessFile File)))
+  (:import (java.io EOFException FileNotFoundException DataInputStream RandomAccessFile File)
+           (java.net URI)
+           (java.nio.file CopyOption Files Paths StandardCopyOption)))
 
 
 ;; if an index is not a positive integer (an append-entry), it is one of these special types:
@@ -16,7 +18,7 @@
 (def ^:const entry-types' (into {} (map (fn [[k v]] [v k]) entry-types)))
 
 
-(defn- write-entry
+(defn write-entry
   "Writes entry to specified log"
   ([^File file index term entry] (write-entry file index term entry true))
   ([^File file index term entry retry?]
@@ -44,6 +46,13 @@
        (log/error e "Fatal Error, exiting.")
        (System/exit 1)))))
 
+(defn write-log
+  "Writes an entire log of entries provided as a sequence. Log entries are 4-tuples (identical format to read-log):
+  [index term entry-type entry-data]"
+  [^File file log]
+  (doseq [[index term _ entry-data] log]
+    (write-entry file index term entry-data false)))
+
 
 (defn write-current-term
   "Record latest term we've seen to persistent log."
@@ -67,38 +76,169 @@
   (write-entry file index (:term entry) entry))
 
 
+(defn log-corrupt-exception
+  "Given an exception thrown that is discovered in a corrupt log file, log its output in a readable format."
+  [exception]
+  (let [{:keys [file-name next-bytes index term]} (ex-data exception)
+        msg        (str "Raft log EOF (End of File) exception reading from file: " file-name ". "
+                        "Successful recovery, returning complete log entries up to the last message. "
+                        "Likely a previous unexpected shutdown happened while writing the corrupted entry. ")
+        error-at   (cond
+                     (nil? next-bytes) "Corruption happened when writing the number of bytes contained in the next entry. "
+                     (nil? index) "Corruption happened when writing the log index number. "
+                     (nil? term) "Corruption happened when writing the raft term number. "
+                     :else "Corruption happened when writing the log entry data. ")
+        known-info (cond
+                     (nil? next-bytes) "No information could be retrieved from the specific log entry."
+                     (nil? index) (str "The log entry was expected to be " next-bytes " bytes.")
+                     (nil? term) (str "The log entry would have been for index: " index " and " next-bytes " bytes.")
+                     :else (str "The log entry would have been for index: " index
+                                " and term: " term " with " next-bytes " bytes."))]
+    (log/warn (str msg error-at known-info))))
+
+(defn move-log
+  "Moves a log file from the source-path to destination-path"
+  [source-path destination-path]
+  (let [source-uri      (URI/create (str "file://" source-path))
+        destination-uri (URI/create (str "file://" destination-path))
+        source          (Paths/get source-uri)
+        destination     (Paths/get destination-uri)]
+    (Files/move source destination
+                (into-array CopyOption [StandardCopyOption/ATOMIC_MOVE
+                                        StandardCopyOption/REPLACE_EXISTING]))))
+
+(defn copy-corrupt-file
+  "Creates a copy (for forensics) of a corrupt raft file using the '.corrupt. extension"
+  [^File file]
+  (let [source-path      (.getPath file)
+        destination-path (str source-path ".corrupt")
+        destination      (io/file destination-path)]
+    (log/info (str "Copying corrupted log file for forensics from: " source-path " to: " destination-path))
+    (io/copy file destination)
+    (log/debug (str "Successfully created file: " destination-path))
+    :done))
+
+(defn repair-file
+  "When we have an end of file exception due to a corrupt final log entry,
+  we need to fix the file so that the log can continue to be used."
+  [^File file log]
+  (try
+    (log/debug (str "About to repair log file: " (.getName file) " with " (count log) " valid entries."))
+    (let [source-path (.getPath file)
+          repair-path (str source-path ".repaired")
+          repair-file (io/file repair-path)]
+      (copy-corrupt-file file)
+      (log/debug (str "Repairing log file: Writing new correct log to: " repair-path " as a temporary file."))
+      (write-log repair-file log)
+      (log/debug (str "Repairing log file: Done writing temporary file: " repair-path
+                      ". Moving temporary file to replace original corrupt log: " source-path))
+      (move-log repair-file source-path)
+      true)
+    (catch Exception e
+      (throw (ex-info (str "Error creating repaired raft log file: " (.getName file)
+                           " with exception: " (ex-message e))
+                      {:file-name (.getName file)}
+                      e)))))
+
+(defn throw-corrupt-file-exception
+  "When reading a raft log file, report out a consistent format for exceptions if they occur."
+  [message exception ^RandomAccessFile raf file-name next-bytes index term entry-type entry-data]
+  (let [file-length  (.length raf)
+        file-pointer (.getFilePointer raf)
+        EOF?         (= file-length file-pointer)]
+    (throw (ex-info message
+                    {:status                 500
+                     :error                  :raft/corrupt-log
+                     :file-name              file-name
+                     :file-length            file-length
+                     :file-pointer           file-pointer
+                     :end-of-file-exception? EOF?
+                     :next-bytes             next-bytes
+                     :index                  index
+                     :term                   term
+                     :entry-type             entry-type
+                     :entry-data             entry-data}
+                    exception))))
+
+(defn read-next-entry
+  "Reads the next entry in a raft log file, returns 4-tuple of:
+  [index term entry-type entry-data] or an ex-info exception if there
+  was an error reading."
+  [^RandomAccessFile raf file-name]
+  (let [next-bytes (try (.readInt raf)
+                        (catch EOFException eof-ex
+                          (throw-corrupt-file-exception (str "Corrupt last entry in raft log: " file-name)
+                                                        eof-ex raf file-name nil nil nil nil nil))
+                        (catch Exception e (throw e)))
+        index      (try (.readLong raf)
+                        (catch EOFException eof-ex
+                          (throw-corrupt-file-exception (str "Corrupt last entry in raft log: " file-name)
+                                                        eof-ex raf file-name next-bytes nil nil nil nil))
+                        (catch Exception e (throw e)))
+        entry-type (if (pos? index) :append-entry (get entry-types' index))
+        term       (try (.readLong raf)
+                        (catch EOFException eof-ex
+                          (throw-corrupt-file-exception (str "Corrupt last entry in raft log: " file-name)
+                                                        eof-ex raf file-name next-bytes index nil entry-type nil))
+                        (catch Exception e (throw e)))
+        ba         (byte-array next-bytes)
+        _          (try (.read raf ba)
+                        (catch EOFException eof-ex
+                          (throw-corrupt-file-exception (str "Corrupt last entry in raft log: " file-name)
+                                                        eof-ex raf file-name next-bytes index term entry-type nil))
+                        (catch Exception e (throw e)))
+        entry-data (try (nippy/thaw ba)
+                        (catch Exception e
+                          (let [EOF?    (= (.length raf) (.getFilePointer raf)) ;; were we reading the last log entry in the file?
+                                message (if EOF?
+                                          (str "Corrupt last entry in raft log: " file-name)
+                                          (str "Unexpected exception when deserializing raft log entry: " file-name))]
+                            (throw-corrupt-file-exception message e raf file-name next-bytes index term entry-type nil))))]
+    [index term entry-type entry-data]))
+
+
 (defn read-log-file
   "Reads entire log file."
   [^File file]
-  (let [raf (RandomAccessFile. file "r")
-        len (.length raf)]
+  (let [raf       (RandomAccessFile. file "r")
+        len       (.length raf)
+        file-name (.getName file)]
     (loop [log []]
       (if (>= (.getFilePointer raf) len)
         (do
           (.close raf)
           log)
-        (let [next-bytes (.readInt raf)
-              ba         (byte-array next-bytes)
-              index      (.readLong raf)
-              term       (.readLong raf)
-              _          (.read raf ba)                     ;; read entry into byte-array
-              entry-type (if (pos? index) :append-entry (get entry-types' index))
-              entry-data (try (nippy/thaw ba)
-                              (catch Exception e (throw (ex-info
-                                                          "Raft log file appears to be corrupt. If you have an existing Raft quorom, (for example, you have 3 servers running and 2 have non-corrupted Raft files), delete raft logs for this server and re-start. It will re-sync from other servers. If you do not have an existing quorom, email support@flur.ee"
+        (let [next-entry (try (read-next-entry raf file-name)
+                              (catch Exception e
+                                (let [EOF?         (-> e ex-data :end-of-file-exception?)
+                                      log-entries  (count log)
+                                      first-entry? (zero? log-entries)
+                                      repairable?  (and EOF? (not first-entry?))]
+                                  (cond repairable? (do
+                                                      (log/warn (str "Repairing corrupt log file, saving a copy to: " file-name ".corrupt"))
+                                                      (log-corrupt-exception e)
+                                                      (.close raf)
+                                                      (repair-file file log)
+                                                      (log/warn (str "Finished repairing corrupt log file: " file-name))
+                                                      :repaired-log)
+                                        first-entry? (do
+                                                       (log/warn "First entry of raft log file is corrupt, removing file after creating a copy.")
+                                                       (log-corrupt-exception e)
+                                                       (.close raf)
+                                                       (copy-corrupt-file file)
+                                                       (.delete file)
+                                                       (log/warn "Successfully removed corrupted log file, restart service.")
+                                                       (log/warn "Exiting! Restart service, which should successfully load last complete log file.")
+                                                       (System/exit 1))
+                                        ;; not repairable, throw exception upstream
+                                        :else (do (.close raf)
+                                                  (throw e))))))]
+          (if (= :repaired-log next-entry)
+            log
+            (recur (conj log next-entry))))))))
 
-                                                          {:file            (.getPath file)
-                                                           :entry-number    (inc (count log))
-                                                           :entry-type-code index
-                                                           :entry-type      entry-type
-                                                           :entry-term      term
-                                                           :entry-bytes     next-bytes
-                                                           :bytes           (vec ba)
-                                                           :error           (.getMessage e)}))))]
-          (recur (conj log [index term entry-type entry-data])))))))
 
-
-(defn- read-entry
+(defn read-entry
   "Reads a specific index entry from durable log.
 
   Entries contain:

--- a/test/fluree/raft/log_test.clj
+++ b/test/fluree/raft/log_test.clj
@@ -1,0 +1,152 @@
+(ns fluree.raft.log-test
+  (:require [clojure.test :refer :all]
+            [clojure.java.io :as io]
+            [taoensso.nippy :as nippy]
+            [test-with-files.tools :refer [with-tmp-dir]]
+            [fluree.raft.log :as raft-log])
+  (:import (java.io File RandomAccessFile)
+           (java.nio ByteBuffer)))
+
+
+(defn corrupt-long
+  "Corrupts a long integer returning corrupted byte array with 7 bytes instead of 8"
+  [long-int]
+  (let [bb (ByteBuffer/allocate 8)]
+    (.putLong bb long-int)
+
+    (->> (.array bb)
+         (take 7)
+         (byte-array))))
+
+(defn corrupt-int
+  "Corrupts an integer returning corrupted byte array with 3 bytes instead of 4"
+  [int]
+  (let [bb (ByteBuffer/allocate 4)]
+    (.putInt bb int)
+
+    (->> (.array bb)
+         (take 3)
+         (byte-array))))
+
+(defn write-corrupt-entry
+  "Writes a corrupt raft log entry, by chopping off the bytes
+  of the serialized entry simulating an incomplete write due to
+  a forced shutdown."
+  [^File file index term entry]
+  (let [^bytes data (nippy/freeze entry)
+        len         (count data)
+        raf         (RandomAccessFile. file "rw")]
+
+    (doto raf
+      (.seek (.length raf))
+      (.writeInt len)
+      (.writeLong index)
+      (.writeLong term)
+      ;; purposefully don't write entry, terminate file here
+      (.close))))
+
+(defn write-corrupt-term
+  "Instead of writing a full term long integer, corrupt it then end writing"
+  [^File file index term entry]
+  (let [^bytes data  (nippy/freeze entry)
+        len          (count data)
+        raf          (RandomAccessFile. file "rw")
+        corrupt-term (corrupt-long term)]
+
+    (doto raf
+      (.seek (.length raf))
+      (.writeInt len)
+      (.writeLong index)
+      (.write corrupt-term)
+      (.close))))
+
+(defn write-corrupt-index
+  "Instead of writing a full index long integer, corrupt it then end writing"
+  [^File file index _ entry]
+  (let [^bytes data   (nippy/freeze entry)
+        len           (count data)
+        raf           (RandomAccessFile. file "rw")
+        corrupt-index (corrupt-long index)]
+
+    (doto raf
+      (.seek (.length raf))
+      (.writeInt len)
+      (.write corrupt-index)
+      (.close))))
+
+(defn write-corrupt-byte-length
+  "Instead of writing the byte length of the entry, corrupt and close."
+  [^File file _ _ entry]
+  (let [^bytes data (nippy/freeze entry)
+        len         (count data)
+        raf         (RandomAccessFile. file "rw")
+        corrupt-len (corrupt-int len)]
+
+    (doto raf
+      (.seek (.length raf))
+      (.write corrupt-len)
+      (.close))))
+
+
+(deftest corrupt-logs
+  (with-tmp-dir temp-dir
+
+    (let [entry1 [:test-command-a {:a 1}]
+          entry2 [:test-command-b {:b 2}]
+          entry3 [:test-command-c {:c 3, :this-will-be :corrupt}]]
+
+      (testing "Corrupted command entry at EOF successfully recovers"
+        (let [file (io/file temp-dir (str 1000 ".raft"))]
+
+          ;; write a first entry normally
+          (raft-log/write-entry file 1 1 entry1)
+          ;; write a second entry normally
+          (raft-log/write-entry file 2 1 entry2)
+          ;; corrupt the third entry
+          (write-corrupt-entry file 3 1 entry3)
+
+          (is (= [[1 1 :append-entry entry1] [2 1 :append-entry entry2]]
+                 (raft-log/read-log-file file))
+              "Read file should have only entry 1 and 2, and not entry 3 which was corrupt")))
+
+      (testing "Corruption when writing term at EOF successfully recovers"
+        (let [file (io/file temp-dir (str 2000 ".raft"))]
+
+          ;; write a first entry normally
+          (raft-log/write-entry file 1 1 entry1)
+          ;; write a second entry normally
+          (raft-log/write-entry file 2 1 entry2)
+          ;; corrupt the third entry
+          (write-corrupt-term file 3 1 entry3)
+
+          (is (= [[1 1 :append-entry entry1] [2 1 :append-entry entry2]]
+                 (raft-log/read-log-file file))
+              "Read file should have only entry 1 and 2, and not entry 3 which was corrupt")))
+
+      (testing "Corruption when writing index at EOF successfully recovers"
+        (let [file (io/file temp-dir (str 3000 ".raft"))]
+
+          ;; write a first entry normally
+          (raft-log/write-entry file 1 1 entry1)
+          ;; write a second entry normally
+          (raft-log/write-entry file 2 1 entry2)
+          ;; corrupt the third entry
+          (write-corrupt-index file 3 1 entry3)
+
+          (is (= [[1 1 :append-entry entry1] [2 1 :append-entry entry2]]
+                 (raft-log/read-log-file file))
+              "Read file should have only entry 1 and 2, and not entry 3 which was corrupt")))
+
+      (testing "Corruption when writing byte length at EOF successfully recovers"
+        (let [file (io/file temp-dir (str 4000 ".raft"))]
+
+          ;; write a first entry normally
+          (raft-log/write-entry file 1 1 entry1)
+          ;; write a second entry normally
+          (raft-log/write-entry file 2 1 entry2)
+          ;; corrupt the third entry
+          (write-corrupt-byte-length file 3 1 entry3)
+
+          (is (= [[1 1 :append-entry entry1] [2 1 :append-entry entry2]]
+                 (raft-log/read-log-file file))
+              "Read file should have only entry 1 and 2, and not entry 3 which was corrupt"))))))

--- a/test/fluree/raft/log_test.clj
+++ b/test/fluree/raft/log_test.clj
@@ -28,10 +28,19 @@
          (take 3)
          (byte-array))))
 
-(defn write-corrupt-entry
-  "Writes a corrupt raft log entry, by chopping off the bytes
-  of the serialized entry simulating an incomplete write due to
-  a forced shutdown."
+(defn corrupt-entry
+  "Corrupts a serialized byte array by chopping the bytes in half."
+  [ba]
+  (let [length       (alength ba)
+        corrupt-size (quot length 2)]
+
+    (->> ba
+         (take corrupt-size)
+         (byte-array))))
+
+(defn write-corrupt-no-entry
+  "Writes a corrupt raft log entry, by not writing any bytes
+  from the log entry simulating a forced shutdown scenario."
   [^File file index term entry]
   (let [^bytes data (nippy/freeze entry)
         len         (count data)
@@ -43,6 +52,24 @@
       (.writeLong index)
       (.writeLong term)
       ;; purposefully don't write entry, terminate file here
+      (.close))))
+
+(defn write-corrupt-partial-entry
+  "Writes a corrupt raft log entry, by chopping off the bytes
+  of the serialized entry simulating an incomplete write due to
+  a forced shutdown."
+  [^File file index term entry]
+  (let [^bytes data  (nippy/freeze entry)
+        len          (count data)
+        corrupt-data (corrupt-entry data)
+        raf          (RandomAccessFile. file "rw")]
+
+    (doto raf
+      (.seek (.length raf))
+      (.writeInt len)
+      (.writeLong index)
+      (.writeLong term)
+      (.write corrupt-data)
       (.close))))
 
 (defn write-corrupt-term
@@ -95,7 +122,7 @@
           entry2 [:test-command-b {:b 2}]
           entry3 [:test-command-c {:c 3, :this-will-be :corrupt}]]
 
-      (testing "Corrupted command entry at EOF successfully recovers"
+      (testing "Corrupted command with chopped off entry at EOF successfully recovers"
         (let [file (io/file temp-dir (str 1000 ".raft"))]
 
           ;; write a first entry normally
@@ -103,7 +130,21 @@
           ;; write a second entry normally
           (raft-log/write-entry file 2 1 entry2)
           ;; corrupt the third entry
-          (write-corrupt-entry file 3 1 entry3)
+          (write-corrupt-no-entry file 3 1 entry3)
+
+          (is (= [[1 1 :append-entry entry1] [2 1 :append-entry entry2]]
+                 (raft-log/read-log-file file))
+              "Read file should have only entry 1 and 2, and not entry 3 which was corrupt")))
+
+      (testing "Corrupted command partially written entry at EOF successfully recovers"
+        (let [file (io/file temp-dir (str 1001 ".raft"))]
+
+          ;; write a first entry normally
+          (raft-log/write-entry file 1 1 entry1)
+          ;; write a second entry normally
+          (raft-log/write-entry file 2 1 entry2)
+          ;; corrupt the third entry
+          (write-corrupt-partial-entry file 3 1 entry3)
 
           (is (= [[1 1 :append-entry entry1] [2 1 :append-entry entry2]]
                  (raft-log/read-log-file file))


### PR DESCRIPTION
Detects a corrupt log file upon raft startup and, if repairable, fixes the file and allows startup to proceed.

Any corrupted log files will be saved with a `.corrupt` extension, e.g. raft log file `1001.raft` will get updated and fixed only after creating a copy of the corrupt file to `1001.raft.corrupt` which can allow for further forensics on the file if necessary.

This scenario happens when a server dies while writing a new entry in the log file, effectively cutting short the full byte array for the entry from getting persisted. When starting up, once getting to the last entry of the log some read/EOF/deserialization exception will occur.

This repair will only happen if the detected corruption is in the last (most recent) log entry. Due to the raft protocol, the server would not have acknowledged the entry was received until it is fully persisted - which means it is OK to remove the corrupted entry as no acknowledgement would have been sent.

In the scenario where the corrupt entry is for a brand new raft file (so it is both the first log entry and the last log entry), it will create a copy using the same `.corrupt` extension, then remove the file entirely, then exist. Upon restart, the server should start normally.

~~The only issue I discovered while working on this fix is that the nippy deserialization of a corrupt entry, which is used for the actual application-specific entry, will sometimes still at times return a valid, but incorrect data structure. Formats like JSON would never return a valid deserialization if it were cut off. Perhaps this is part of the speed tradeoff nippy makes, but it seems like we should perhaps include a checksum in the log entry to verify the entry is complete, or consider defaulting to a different serde format. In order to do this work, we'd need to update the file format to embed at minimum a format version number, new file extension, or other mechanism to ensure both the old and new formats were supported.~~

The above comment was addressed with now using the `.readFully` method instead of `.read`. This ensures the read tries to fully fill up the byte array, and if there are not enough bytes left in the file it will throw an EOF exception. Now we always know we retrieved all bytes for nippy, and won't have the improper deserialization issue any longer.


